### PR TITLE
Sendable expressions instead of mainactor

### DIFF
--- a/Sources/AsyncExpectations/AsyncExpectations.swift
+++ b/Sources/AsyncExpectations/AsyncExpectations.swift
@@ -9,10 +9,10 @@ import QuartzCore
 ///   - expression: An expression of Boolean type.
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
-@MainActor public func expect(timeout: TimeInterval = 1,
-                              _ expression: @MainActor @escaping () async throws -> Bool,
-                              file: StaticString = #file,
-                              line: UInt = #line) async throws {
+public func expect(timeout: TimeInterval = 1,
+                   _ expression: @Sendable @escaping () async throws -> Bool,
+                   file: StaticString = #file,
+                   line: UInt = #line) async throws {
     if try await !evaluate(expression, timeout: timeout) {
         failExpect(file: file, line: line)
     }
@@ -23,10 +23,10 @@ import QuartzCore
 ///   - expression: An expression of Boolean type.
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
-@MainActor public func expect(timeout: TimeInterval = 1,
-                              _ expression: @escaping @autoclosure () throws -> Bool,
-                              file: StaticString = #file,
-                              line: UInt = #line) async throws {
+public func expect(timeout: TimeInterval = 1,
+                   _ expression: @Sendable @escaping @autoclosure () throws -> Bool,
+                   file: StaticString = #file,
+                   line: UInt = #line) async throws {
     if try await !evaluate(expression, timeout: timeout) {
         failExpect(file: file, line: line)
     }
@@ -41,11 +41,11 @@ private func failExpect(file: StaticString, line: UInt) {
 ///   - expression: An expression of Boolean type.
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
-@MainActor public func expectFalse(timeout: TimeInterval = 1,
-                                   _ expression: @MainActor @escaping () async throws -> Bool,
-                                   file: StaticString = #file,
-                                   line: UInt = #line) async throws {
-    let inverted = { try await expression() != true }
+public func expectFalse(timeout: TimeInterval = 1,
+                        _ expression: @Sendable @escaping () async throws -> Bool,
+                        file: StaticString = #file,
+                        line: UInt = #line) async throws {
+    let inverted = { @Sendable in try await expression() != true }
     if try await !evaluate(inverted, timeout: timeout) {
         failExpecFalse(file: file, line: line)
     }
@@ -56,11 +56,11 @@ private func failExpect(file: StaticString, line: UInt) {
 ///   - expression: An expression of Boolean type.
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
-@MainActor public func expectFalse(timeout: TimeInterval = 1,
-                                   _ expression: @escaping @autoclosure () throws -> Bool,
-                                   file: StaticString = #file,
-                                   line: UInt = #line) async throws {
-    let inverted = { try expression() != true }
+public func expectFalse(timeout: TimeInterval = 1,
+                        _ expression: @Sendable @escaping @autoclosure () throws -> Bool,
+                        file: StaticString = #file,
+                        line: UInt = #line) async throws {
+    let inverted = { @Sendable in try expression() != true }
     if try await !evaluate(inverted, timeout: timeout) {
         failExpecFalse(file: file, line: line)
     }
@@ -76,12 +76,12 @@ private func failExpecFalse(file: StaticString, line: UInt) {
 ///   - expression2: A second expression of type T, where T is Equatable.
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
-@MainActor public func expectEqual<T: Equatable>(timeout: TimeInterval = 1,
-                                                 _ expression1: @escaping @autoclosure () throws -> T,
-                                                 _ expression2: @escaping @autoclosure () throws -> T,
-                                                 file: StaticString = #file,
-                                                 line: UInt = #line) async throws {
-    let expression = {
+public func expectEqual<T: Equatable>(timeout: TimeInterval = 1,
+                                      _ expression1: @Sendable @escaping @autoclosure () throws -> T,
+                                      _ expression2: @Sendable @escaping @autoclosure () throws -> T,
+                                      file: StaticString = #file,
+                                      line: UInt = #line) async throws {
+    let expression = { @Sendable in
         let first = try expression1()
         let second = try expression2()
         return first == second
@@ -99,12 +99,12 @@ private func failExpecFalse(file: StaticString, line: UInt) {
 ///   - expression2: A second expression of type T, where T is Equatable.
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
-@MainActor public func expectEqual<T: Equatable>(timeout: TimeInterval = 1,
-                                                 _ expression1: @MainActor @escaping () async throws -> T,
-                                                 _ expression2: @MainActor @escaping () async throws -> T,
-                                                 file: StaticString = #file,
-                                                 line: UInt = #line) async throws {
-    let expression = {
+public func expectEqual<T: Equatable>(timeout: TimeInterval = 1,
+                                      _ expression1: @Sendable @escaping () async throws -> T,
+                                      _ expression2: @Sendable @escaping () async throws -> T,
+                                      file: StaticString = #file,
+                                      line: UInt = #line) async throws {
+    let expression = { @Sendable in
         let first = try await expression1()
         let second = try await expression2()
         return first == second
@@ -126,12 +126,12 @@ private func failExpectEqual<T>(first: T, second: T, file: StaticString, line: U
 ///   - expression2: A second expression of type T, where T is Equatable.
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
-@MainActor public func expectNotEqual<T: Equatable>(timeout: TimeInterval = 1,
-                                                    _ expression1: @escaping @autoclosure () throws -> T,
-                                                    _ expression2: @escaping @autoclosure () throws -> T,
-                                                    file: StaticString = #file,
-                                                    line: UInt = #line) async throws {
-    let expression = {
+public func expectNotEqual<T: Equatable>(timeout: TimeInterval = 1,
+                                         _ expression1: @Sendable @escaping @autoclosure () throws -> T,
+                                         _ expression2: @Sendable @escaping @autoclosure () throws -> T,
+                                         file: StaticString = #file,
+                                         line: UInt = #line) async throws {
+    let expression = { @Sendable in
         let first = try expression1()
         let second = try expression2()
         return first != second
@@ -149,12 +149,12 @@ private func failExpectEqual<T>(first: T, second: T, file: StaticString, line: U
 ///   - expression2: A second expression of type T, where T is Equatable.
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
-@MainActor public func expectNotEqual<T: Equatable>(timeout: TimeInterval = 1,
-                                                    _ expression1: @MainActor @escaping () async throws -> T,
-                                                    _ expression2: @MainActor @escaping () async throws -> T,
-                                                    file: StaticString = #file,
-                                                    line: UInt = #line) async throws {
-    let expression = {
+public func expectNotEqual<T: Equatable>(timeout: TimeInterval = 1,
+                                         _ expression1: @Sendable @escaping () async throws -> T,
+                                         _ expression2: @Sendable @escaping () async throws -> T,
+                                         file: StaticString = #file,
+                                         line: UInt = #line) async throws {
+    let expression = { @Sendable in
         let first = try await expression1()
         let second = try await expression2()
         return first != second
@@ -175,11 +175,11 @@ private func failExpectNotEqual<T>(first: T, second: T, file: StaticString, line
 ///   - expression: An expression of type T.
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
-@MainActor public func expectNotNil<T>(timeout: TimeInterval = 1,
-                                       _ expression: @escaping @autoclosure () throws -> T?,
-                                       file: StaticString = #file,
-                                       line: UInt = #line) async throws {
-    let expression = { return try expression() != nil }
+public func expectNotNil<T>(timeout: TimeInterval = 1,
+                            _ expression: @Sendable @escaping @autoclosure () throws -> T?,
+                            file: StaticString = #file,
+                            line: UInt = #line) async throws {
+    let expression = { @Sendable in return try expression() != nil }
     if try await !evaluate(expression, timeout: timeout) {
         failExpectNotNil(file: file, line: line)
     }
@@ -190,11 +190,11 @@ private func failExpectNotEqual<T>(first: T, second: T, file: StaticString, line
 ///   - expression: An expression of type T.
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
-@MainActor public func expectNotNil<T>(timeout: TimeInterval = 1,
-                                       _ expression: @MainActor @escaping () async throws -> T?,
-                                       file: StaticString = #file,
-                                       line: UInt = #line) async throws {
-    let expression = { return try await expression() != nil }
+public func expectNotNil<T>(timeout: TimeInterval = 1,
+                            _ expression: @Sendable @escaping () async throws -> T?,
+                            file: StaticString = #file,
+                            line: UInt = #line) async throws {
+    let expression = { @Sendable in return try await expression() != nil }
     if try await !evaluate(expression, timeout: timeout) {
         failExpectNotNil(file: file, line: line)
     }
@@ -209,11 +209,11 @@ private func failExpectNotNil(file: StaticString, line: UInt) {
 ///   - expression: An expression of type T.
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
-@MainActor public func expectNil<T>(timeout: TimeInterval = 1,
-                                    _ expression: @escaping @autoclosure () throws -> T?,
-                                    file: StaticString = #file,
-                                    line: UInt = #line) async throws {
-    let expression = { return try expression() == nil }
+public func expectNil<T>(timeout: TimeInterval = 1,
+                         _ expression: @Sendable @escaping @autoclosure () throws -> T?,
+                         file: StaticString = #file,
+                         line: UInt = #line) async throws {
+    let expression = { @Sendable in return try expression() == nil }
     if try await !evaluate(expression, timeout: timeout) {
         failExpectNil(file: file, line: line)
     }
@@ -224,11 +224,11 @@ private func failExpectNotNil(file: StaticString, line: UInt) {
 ///   - expression: An expression of type T.
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
-@MainActor public func expectNil<T>(timeout: TimeInterval = 1,
-                                    _ expression: @MainActor @escaping () async throws -> T?,
-                                    file: StaticString = #file,
-                                    line: UInt = #line) async throws {
-    let expression = { return try await expression() == nil }
+public func expectNil<T>(timeout: TimeInterval = 1,
+                         _ expression: @Sendable @escaping () async throws -> T?,
+                         file: StaticString = #file,
+                         line: UInt = #line) async throws {
+    let expression = { @Sendable in return try await expression() == nil }
     if try await !evaluate(expression, timeout: timeout) {
         failExpectNil(file: file, line: line)
     }
@@ -244,12 +244,12 @@ private func failExpectNil(file: StaticString, line: UInt) {
 ///   - errorHandler: An optional error handler.
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
-@MainActor public func expectThrowsError<T>(timeout: TimeInterval = 1,
-                                            _ expression:  @escaping @autoclosure () throws -> T,
-                                            errorHandler: ((Error) -> Void)? = nil,
-                                            file: StaticString = #file,
-                                            line: UInt = #line) async throws {
-    let expression = {
+public func expectThrowsError<T>(timeout: TimeInterval = 1,
+                                 _ expression:  @Sendable @escaping @autoclosure () throws -> T,
+                                 errorHandler: ((Error) -> Void)? = nil,
+                                 file: StaticString = #file,
+                                 line: UInt = #line) async throws {
+    let expression = { @Sendable in
         do {
             _ = try expression()
             return false
@@ -269,12 +269,12 @@ private func failExpectNil(file: StaticString, line: UInt) {
 ///   - errorHandler: An optional error handler.
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
-@MainActor public func expectThrowsError<T>(timeout: TimeInterval = 1,
-                                            _ expression: @MainActor @escaping () async throws -> T,
-                                            errorHandler: ((Error) -> Void)? = nil,
-                                            file: StaticString = #file,
-                                            line: UInt = #line) async throws {
-    let expression = {
+public func expectThrowsError<T>(timeout: TimeInterval = 1,
+                                 _ expression: @Sendable @escaping () async throws -> T,
+                                 errorHandler: ((Error) -> Void)? = nil,
+                                 file: StaticString = #file,
+                                 line: UInt = #line) async throws {
+    let expression = { @Sendable in
         do {
             _ = try await expression()
             return false
@@ -297,11 +297,11 @@ private func failExpectThrowsError(file: StaticString, line: UInt) {
 ///   - expression: An expression of type T.
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
-@MainActor public func expectNoThrow<T>(timeout: TimeInterval = 1,
-                                        _ expression: @autoclosure @escaping () throws -> T,
-                                        file: StaticString = #file,
-                                        line: UInt = #line) async throws {
-    let expression = {
+public func expectNoThrow<T>(timeout: TimeInterval = 1,
+                             _ expression: @autoclosure @escaping () throws -> T,
+                             file: StaticString = #file,
+                             line: UInt = #line) async throws {
+    let expression = { @Sendable in
         do {
             _ = try expression()
             return true
@@ -319,11 +319,11 @@ private func failExpectThrowsError(file: StaticString, line: UInt) {
 ///   - expression: An expression of type T.
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
-@MainActor public func expectNoThrow<T>(timeout: TimeInterval = 1,
-                                        _ expression: @MainActor @escaping () async throws -> T,
-                                        file: StaticString = #file,
-                                        line: UInt = #line) async throws {
-    let expression = {
+public func expectNoThrow<T>(timeout: TimeInterval = 1,
+                             _ expression: @Sendable @escaping () async throws -> T,
+                             file: StaticString = #file,
+                             line: UInt = #line) async throws {
+    let expression = { @Sendable in
         do {
             _ = try await expression()
             return true
@@ -346,12 +346,12 @@ private func failExpectNoThrow(file: StaticString, line: UInt) {
 ///   - expression2: A second expression of type T, where T is Comparable.
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
-@MainActor public func expectLessThan<T: Comparable>(timeout: TimeInterval = 1,
-                                                     _ expression1: @escaping @autoclosure () throws -> T,
-                                                     _ expression2: @escaping @autoclosure () throws -> T,
-                                                     file: StaticString = #file,
-                                                     line: UInt = #line) async throws {
-    let expression = {
+public func expectLessThan<T: Comparable>(timeout: TimeInterval = 1,
+                                          _ expression1: @Sendable @escaping @autoclosure () throws -> T,
+                                          _ expression2: @Sendable @escaping @autoclosure () throws -> T,
+                                          file: StaticString = #file,
+                                          line: UInt = #line) async throws {
+    let expression = { @Sendable in
         let first = try expression1()
         let second = try expression2()
         return first < second
@@ -369,12 +369,12 @@ private func failExpectNoThrow(file: StaticString, line: UInt) {
 ///   - expression2: A second expression of type T, where T is Comparable.
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
-@MainActor public func expectLessThan<T: Comparable>(timeout: TimeInterval = 1,
-                                                     _ expression1: @MainActor @escaping () async throws -> T,
-                                                     _ expression2: @MainActor @escaping () async throws -> T,
-                                                     file: StaticString = #file,
-                                                     line: UInt = #line) async throws {
-    let expression = {
+public func expectLessThan<T: Comparable>(timeout: TimeInterval = 1,
+                                          _ expression1: @Sendable @escaping () async throws -> T,
+                                          _ expression2: @Sendable @escaping () async throws -> T,
+                                          file: StaticString = #file,
+                                          line: UInt = #line) async throws {
+    let expression = { @Sendable in
         let first = try await expression1()
         let second = try await expression2()
         return first < second
@@ -396,12 +396,12 @@ private func failExpectLessThan<T>(first: T, second: T, file: StaticString, line
 ///   - expression2: A second expression of type T, where T is Comparable.
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
-@MainActor public func expectLessThanOrEqual<T: Comparable>(timeout: TimeInterval = 1,
-                                                            _ expression1: @escaping @autoclosure () throws -> T,
-                                                            _ expression2: @escaping  @autoclosure () throws -> T,
-                                                            file: StaticString = #file,
-                                                            line: UInt = #line) async throws {
-    let expression = {
+public func expectLessThanOrEqual<T: Comparable>(timeout: TimeInterval = 1,
+                                                 _ expression1: @Sendable @escaping @autoclosure () throws -> T,
+                                                 _ expression2: @escaping  @autoclosure () throws -> T,
+                                                 file: StaticString = #file,
+                                                 line: UInt = #line) async throws {
+    let expression = { @Sendable in
         let first = try expression1()
         let second = try expression2()
         return first <= second
@@ -419,12 +419,12 @@ private func failExpectLessThan<T>(first: T, second: T, file: StaticString, line
 ///   - expression2: A second expression of type T, where T is Comparable.
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
-@MainActor public func expectLessThanOrEqual<T: Comparable>(timeout: TimeInterval = 1,
-                                                            _ expression1: @MainActor @escaping () async throws -> T,
-                                                            _ expression2: @MainActor @escaping () async throws -> T,
-                                                            file: StaticString = #file,
-                                                            line: UInt = #line) async throws {
-    let expression = {
+public func expectLessThanOrEqual<T: Comparable>(timeout: TimeInterval = 1,
+                                                 _ expression1: @Sendable @escaping () async throws -> T,
+                                                 _ expression2: @Sendable @escaping () async throws -> T,
+                                                 file: StaticString = #file,
+                                                 line: UInt = #line) async throws {
+    let expression = { @Sendable in
         let first = try await expression1()
         let second = try await expression2()
         return first <= second
@@ -446,12 +446,12 @@ private func failExpectLessThanOrEqual<T>(first: T, second: T, file: StaticStrin
 ///   - expression2: A second expression of type T, where T is Comparable.
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
-@MainActor public func expectGreaterThan<T: Comparable>(timeout: TimeInterval = 1,
-                                                        _ expression1: @escaping @autoclosure () throws -> T,
-                                                        _ expression2: @escaping  @autoclosure () throws -> T,
-                                                        file: StaticString = #file,
-                                                        line: UInt = #line) async throws {
-    let expression = {
+public func expectGreaterThan<T: Comparable>(timeout: TimeInterval = 1,
+                                             _ expression1: @Sendable @escaping @autoclosure () throws -> T,
+                                             _ expression2: @escaping  @autoclosure () throws -> T,
+                                             file: StaticString = #file,
+                                             line: UInt = #line) async throws {
+    let expression = { @Sendable in
         let first = try expression1()
         let second = try expression2()
         return first > second
@@ -469,12 +469,12 @@ private func failExpectLessThanOrEqual<T>(first: T, second: T, file: StaticStrin
 ///   - expression2: A second expression of type T, where T is Comparable.
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
-@MainActor public func expectGreaterThan<T: Comparable>(timeout: TimeInterval = 1,
-                                                        _ expression1: @MainActor @escaping () async throws -> T,
-                                                        _ expression2: @MainActor @escaping () async throws -> T,
-                                                        file: StaticString = #file,
-                                                        line: UInt = #line) async throws {
-    let expression = {
+public func expectGreaterThan<T: Comparable>(timeout: TimeInterval = 1,
+                                             _ expression1: @Sendable @escaping () async throws -> T,
+                                             _ expression2: @Sendable @escaping () async throws -> T,
+                                             file: StaticString = #file,
+                                             line: UInt = #line) async throws {
+    let expression = { @Sendable in
         let first = try await expression1()
         let second = try await expression2()
         return first > second
@@ -496,12 +496,12 @@ private func failExpectGreaterThan<T>(first: T, second: T, file: StaticString, l
 ///   - expression2: A second expression of type T, where T is Comparable.
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
-@MainActor public func expectGreaterThanOrEqual<T: Comparable>(timeout: TimeInterval = 1,
-                                                               _ expression1: @escaping @autoclosure () throws -> T,
-                                                               _ expression2: @escaping @autoclosure () throws -> T,
-                                                               file: StaticString = #file,
-                                                               line: UInt = #line) async throws {
-    let expression = {
+public func expectGreaterThanOrEqual<T: Comparable>(timeout: TimeInterval = 1,
+                                                    _ expression1: @Sendable @escaping @autoclosure () throws -> T,
+                                                    _ expression2: @Sendable @escaping @autoclosure () throws -> T,
+                                                    file: StaticString = #file,
+                                                    line: UInt = #line) async throws {
+    let expression = { @Sendable in
         let first = try expression1()
         let second = try expression2()
         return first >= second
@@ -519,12 +519,12 @@ private func failExpectGreaterThan<T>(first: T, second: T, file: StaticString, l
 ///   - expression2: A second expression of type T, where T is Comparable.
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
-@MainActor public func expectGreaterThanOrEqual<T: Comparable>(timeout: TimeInterval = 1,
-                                                               _ expression1: @MainActor @escaping () async throws -> T,
-                                                               _ expression2: @MainActor @escaping () async throws -> T,
-                                                               file: StaticString = #file,
-                                                               line: UInt = #line) async throws {
-    let expression = {
+public func expectGreaterThanOrEqual<T: Comparable>(timeout: TimeInterval = 1,
+                                                    _ expression1: @Sendable @escaping () async throws -> T,
+                                                    _ expression2: @Sendable @escaping () async throws -> T,
+                                                    file: StaticString = #file,
+                                                    line: UInt = #line) async throws {
+    let expression = { @Sendable in
         let first = try await expression1()
         let second = try await expression2()
         return first >= second
@@ -546,11 +546,11 @@ private func failExpectGreaterThanOrEqual<T>(first: T, second: T, file: StaticSt
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
 @discardableResult
-@MainActor public func expectValue<T>(timeout: TimeInterval = 1,
-                                      _ expression: @MainActor @escaping () async throws -> T?,
-                                      file: StaticString = #file,
-                                      line: UInt = #line) async throws -> T {
-    let expressionToSend = {
+public func expectValue<T>(timeout: TimeInterval = 1,
+                           _ expression: @Sendable @escaping () async throws -> T?,
+                           file: StaticString = #file,
+                           line: UInt = #line) async throws -> T? {
+    let expressionToSend = { @Sendable in
         try await expression() != nil
     }
     if try await evaluate(expressionToSend, timeout: timeout) {
@@ -567,11 +567,11 @@ private func failExpectGreaterThanOrEqual<T>(first: T, second: T, file: StaticSt
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
 @discardableResult
-@MainActor public func expectValue<T>(timeout: TimeInterval = 1,
-                                      _ expression: @escaping @autoclosure () throws -> T?,
-                                      file: StaticString = #file,
-                                      line: UInt = #line) async throws -> T {
-    let expressionToSend = {
+public func expectValue<T>(timeout: TimeInterval = 1,
+                           _ expression: @Sendable @escaping @autoclosure () throws -> T?,
+                           file: StaticString = #file,
+                           line: UInt = #line) async throws -> T {
+    let expressionToSend = { @Sendable in
         try expression() != nil
     }
     if try await evaluate(expressionToSend, timeout: timeout) {
@@ -581,50 +581,7 @@ private func failExpectGreaterThanOrEqual<T>(first: T, second: T, file: StaticSt
         throw ExpectValueFailed()
     }
 }
-/// Expects the expression to return a value.
-/// - Parameters:
-///   - timeout: The amount of time to wait before recording a test failure.
-///   - expression: An expression of type T.
-///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
-///   - line: The line number where the failure occurs. The default is the line number where you call this function.
-@discardableResult
-@MainActor public func expectValue<T>(timeout: TimeInterval = 1,
-                                      _ expression: @MainActor @escaping () async throws -> T,
-                                      file: StaticString = #file,
-                                      line: UInt = #line) async throws -> T {
-    let expressionToSend = {
-        _ = try await expression()
-        return true
-    }
-    if try await evaluate(expressionToSend, timeout: timeout) {
-        return try await expression()
-    } else {
-        failExpectValue(file: file, line: line)
-        throw ExpectValueFailed()
-    }
-}
-/// Expects the expression to return a value.
-/// - Parameters:
-///   - timeout: The amount of time to wait before recording a test failure.
-///   - expression: An expression of type T.
-///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
-///   - line: The line number where the failure occurs. The default is the line number where you call this function.
-@discardableResult
-@MainActor public func expectValue<T>(timeout: TimeInterval = 1,
-                                      _ expression: @escaping @autoclosure () throws -> T,
-                                      file: StaticString = #file,
-                                      line: UInt = #line) async throws -> T {
-    let expressionToSend = {
-        _ = try expression()
-        return true
-    }
-    if try await evaluate(expressionToSend, timeout: timeout) {
-        return try expression()
-    } else {
-        failExpectValue(file: file, line: line)
-        throw ExpectValueFailed()
-    }
-}
+
 /// Expects the expression to return a value.
 /// - Parameters:
 ///   - timeout: The amount of time to wait before recording a test failure.
@@ -661,8 +618,8 @@ private func failExpectValue(file: StaticString, line: UInt) {
 /// - Parameters:
 ///   - expression: An expression of Boolean type.
 ///   - timeout: The amount of time to wait to evaluate the expression.
-@MainActor public func evaluate(_ expression: @MainActor @escaping () async throws -> Bool,
-                                timeout: TimeInterval) async throws -> Bool {
+public func evaluate(_ expression: @Sendable @escaping () async throws -> Bool,
+                     timeout: TimeInterval) async throws -> Bool {
     actor ExpressionStatus {
         var isFulfilled = false
         func setIsFulfilled() {

--- a/Tests/AsyncExpectationsTests/ExpectEqualTests.swift
+++ b/Tests/AsyncExpectationsTests/ExpectEqualTests.swift
@@ -2,30 +2,13 @@ import XCTest
 @testable import AsyncExpectations
 
 final class ExpectEqualTests: XCTestCase {
-    func testExpectEqualShouldFail() throws {
-        XCTExpectFailure {
-            let expectation = expectation(description: #function)
-            Task {
-                defer {
-                    expectation.fulfill()
-                }
-                try await expectEqual(timeout: 0.1, { 1 }, { 2 })
-            }
-            wait(for: [expectation], timeout: 1)
-            
-        }
+    func testExpectEqualShouldFail() async throws {
+        try await expectEqual(timeout: 0.1, { 1 }, { 2 })
+        XCTExpectFailure()
     }
-    func testExpectEqualShouldFailAutoClosure() throws {
-        XCTExpectFailure {
-            let expectation = expectation(description: #function)
-            Task {
-                defer {
-                    expectation.fulfill()
-                }
-                try await expectEqual(timeout: 0.1, 1, 2)
-            }
-            wait(for: [expectation], timeout: 1)
-        }
+    func testExpectEqualShouldFailAutoClosure() async throws {
+        try await expectEqual(timeout: 0.1, 1, 2)
+        XCTExpectFailure()
     }
     func testExpectEqualShouldSucceed() async throws {
         try await expectEqual(1, 1)

--- a/Tests/AsyncExpectationsTests/ExpectFalseTests.swift
+++ b/Tests/AsyncExpectationsTests/ExpectFalseTests.swift
@@ -2,30 +2,13 @@ import XCTest
 @testable import AsyncExpectations
 
 final class ExpectFalseTests: XCTestCase {
-    func testExpectFalseShouldFail() throws {
-        XCTExpectFailure {
-            let expectation = expectation(description: #function)
-            Task {
-                defer {
-                    expectation.fulfill()
-                }
-                try await expectFalse(timeout: 0.1, { return true })
-            }
-            wait(for: [expectation], timeout: 1)
-            
-        }
+    func testExpectFalseShouldFail() async throws {
+        try await expectFalse(timeout: 0.1, { return true })
+        XCTExpectFailure()
     }
-    func testExpectFalseShouldFailAutoClosure() throws {
-        XCTExpectFailure {
-            let expectation = expectation(description: #function)
-            Task {
-                defer {
-                    expectation.fulfill()
-                }
-                try await expectFalse(timeout: 0.1, true)
-            }
-            wait(for: [expectation], timeout: 1)
-        }
+    func testExpectFalseShouldFailAutoClosure() async throws {
+        try await expectFalse(timeout: 0.1, true)
+        XCTExpectFailure()
     }
     
     func testExpectFalseShouldSucceed() async throws {
@@ -36,11 +19,11 @@ final class ExpectFalseTests: XCTestCase {
     }
     @MainActor
     func testExpectFalseShouldSucceedAutoClosure() async throws {
-        var fulfilledInverted = true
+        let fulfilledInverted = LockIsolated(true)
         Task { @MainActor in
             try await Task.sleep(nanoseconds: NSEC_PER_SEC / 10)
-            fulfilledInverted = false
+            fulfilledInverted.setValue(false)
         }
-        try await expectFalse(fulfilledInverted)
+        try await expectFalse(fulfilledInverted.value)
     }
 }

--- a/Tests/AsyncExpectationsTests/ExpectGreaterThanOrEqualTests.swift
+++ b/Tests/AsyncExpectationsTests/ExpectGreaterThanOrEqualTests.swift
@@ -2,30 +2,13 @@ import XCTest
 @testable import AsyncExpectations
 
 final class ExpectGreaterThanOrEqualTests: XCTestCase {
-    func testExpectGreaterThanOrEqualShouldFail() throws {
-        XCTExpectFailure {
-            let expectation = expectation(description: #function)
-            Task {
-                defer {
-                    expectation.fulfill()
-                }
-                try await expectGreaterThanOrEqual(timeout: 0.1, { 2 }, { 3 })
-            }
-            wait(for: [expectation], timeout: 1)
-            
-        }
+    func testExpectGreaterThanOrEqualShouldFail() async throws {
+        try await expectGreaterThanOrEqual(timeout: 0.1, { 2 }, { 3 })
+        XCTExpectFailure()
     }
-    func testExpectGreaterThanOrEqualShouldFailAutoClosure() throws {
-        XCTExpectFailure {
-            let expectation = expectation(description: #function)
-            Task {
-                defer {
-                    expectation.fulfill()
-                }
-                try await expectGreaterThanOrEqual(timeout: 0.1, 2, 10)
-            }
-            wait(for: [expectation], timeout: 1)
-        }
+    func testExpectGreaterThanOrEqualShouldFailAutoClosure() async throws {
+        try await expectGreaterThanOrEqual(timeout: 0.1, 2, 10)
+        XCTExpectFailure()
     }
     func testExpectGreaterThanOrEqualShouldSucceed() async throws {
         try await expectGreaterThanOrEqual(2.0, 2.0)

--- a/Tests/AsyncExpectationsTests/ExpectGreaterThanTests.swift
+++ b/Tests/AsyncExpectationsTests/ExpectGreaterThanTests.swift
@@ -2,30 +2,13 @@ import XCTest
 @testable import AsyncExpectations
 
 final class ExpectGreaterThanTests: XCTestCase {
-    func testExpectGreaterThanShouldFail() throws {
-        XCTExpectFailure {
-            let expectation = expectation(description: #function)
-            Task {
-                defer {
-                    expectation.fulfill()
-                }
-                try await expectGreaterThan(timeout: 0.1, { 2 }, { 3 })
-            }
-            wait(for: [expectation], timeout: 1)
-            
-        }
+    func testExpectGreaterThanShouldFail() async throws {
+        try await expectGreaterThan(timeout: 0.1, { 2 }, { 3 })
+        XCTExpectFailure()
     }
-    func testExpectGreaterThanShouldFailAutoClosure() throws {
-        XCTExpectFailure {
-            let expectation = expectation(description: #function)
-            Task {
-                defer {
-                    expectation.fulfill()
-                }
-                try await expectGreaterThan(timeout: 0.1, 2, 10)
-            }
-            wait(for: [expectation], timeout: 1)
-        }
+    func testExpectGreaterThanShouldFailAutoClosure() async throws {
+        try await expectGreaterThan(timeout: 0.1, 2, 10)
+        XCTExpectFailure()
     }
     func testExpectGreaterThanShouldSucceed() async throws {
         try await expectGreaterThan(10, 2.0)

--- a/Tests/AsyncExpectationsTests/ExpectLessThanOrEqualTests.swift
+++ b/Tests/AsyncExpectationsTests/ExpectLessThanOrEqualTests.swift
@@ -2,30 +2,13 @@ import XCTest
 @testable import AsyncExpectations
 
 final class ExpectLessThanOrEqualTests: XCTestCase {
-    func testExpectLessThanOrEqualShouldFail() throws {
-        XCTExpectFailure {
-            let expectation = expectation(description: #function)
-            Task {
-                defer {
-                    expectation.fulfill()
-                }
-                try await expectLessThanOrEqual(timeout: 0.1, { 3 }, { 2 })
-            }
-            wait(for: [expectation], timeout: 1)
-            
-        }
+    func testExpectLessThanOrEqualShouldFail() async throws {
+        try await expectLessThanOrEqual(timeout: 0.1, { 3 }, { 2 })
+        XCTExpectFailure()
     }
-    func testExpectLessThanOrEqualShouldFailAutoClosure() throws {
-        XCTExpectFailure {
-            let expectation = expectation(description: #function)
-            Task {
-                defer {
-                    expectation.fulfill()
-                }
-                try await expectLessThanOrEqual(timeout: 0.1, 10, 2)
-            }
-            wait(for: [expectation], timeout: 1)
-        }
+    func testExpectLessThanOrEqualShouldFailAutoClosure() async throws {
+        try await expectLessThanOrEqual(timeout: 0.1, 10, 2)
+        XCTExpectFailure()
     }
     func testExpectLessThanOrEqualShouldSucceed() async throws {
         try await expectLessThanOrEqual(2, 2)

--- a/Tests/AsyncExpectationsTests/ExpectLessThanTests.swift
+++ b/Tests/AsyncExpectationsTests/ExpectLessThanTests.swift
@@ -2,30 +2,13 @@ import XCTest
 @testable import AsyncExpectations
 
 final class ExpectLessThanTests: XCTestCase {
-    func testExpectLessThanShouldFail() throws {
-        XCTExpectFailure {
-            let expectation = expectation(description: #function)
-            Task {
-                defer {
-                    expectation.fulfill()
-                }
-                try await expectLessThan(timeout: 0.1, { 2 }, { 2 })
-            }
-            wait(for: [expectation], timeout: 1)
-            
-        }
+    func testExpectLessThanShouldFail() async throws {
+        try await expectLessThan(timeout: 0.1, { 2 }, { 2 })
+        XCTExpectFailure()
     }
-    func testExpectLessThanShouldFailAutoClosure() throws {
-        XCTExpectFailure {
-            let expectation = expectation(description: #function)
-            Task {
-                defer {
-                    expectation.fulfill()
-                }
-                try await expectLessThan(timeout: 0.1, 3, 2)
-            }
-            wait(for: [expectation], timeout: 1)
-        }
+    func testExpectLessThanShouldFailAutoClosure() async throws {
+        try await expectLessThan(timeout: 0.1, 3, 2)
+        XCTExpectFailure()
     }
     func testExpectLessThanShouldSucceed() async throws {
         try await expectLessThan(1, 2)

--- a/Tests/AsyncExpectationsTests/ExpectNoThrowTests.swift
+++ b/Tests/AsyncExpectationsTests/ExpectNoThrowTests.swift
@@ -26,7 +26,7 @@ final class ExpectNoThrowTests: XCTestCase {
         }
     }
     func testExpectNoThrowShouldSucceedAutoClosure() async throws {
-        func noThrow() async throws {
+        @Sendable func noThrow() async throws {
             try await Task.sleep(nanoseconds: NSEC_PER_SEC / 10)
         }
         try await expectNoThrow {

--- a/Tests/AsyncExpectationsTests/ExpectNoThrowTests.swift
+++ b/Tests/AsyncExpectationsTests/ExpectNoThrowTests.swift
@@ -2,38 +2,22 @@ import XCTest
 @testable import AsyncExpectations
 
 final class ExpectNoThrowTests: XCTestCase {
-    func testExpectNoThrowShouldFail() throws {
+    func testExpectNoThrowShouldFail() async throws {
         @Sendable func funcThatThrows() async throws {
             try await Task.sleep(nanoseconds: NSEC_PER_SEC / 10)
             throw "Foo"
         }
-        XCTExpectFailure {
-            let expectation = expectation(description: #function)
-            Task {
-                defer {
-                    expectation.fulfill()
-                }
-                try await expectNoThrow(timeout: 0.1) {
-                    try await funcThatThrows()
-                }
-            }
-            wait(for: [expectation], timeout: 1)
+        try await expectNoThrow(timeout: 0.1) {
+            try await funcThatThrows()
         }
+        XCTExpectFailure()
     }
-    func testExpectNoThrowShouldFailAutoClosure() throws {
+    func testExpectNoThrowShouldFailAutoClosure() async throws {
         @Sendable func funcThatThrows() throws {
             throw "Foo"
         }
-        XCTExpectFailure {
-            let expectation = expectation(description: #function)
-            Task {
-                defer {
-                    expectation.fulfill()
-                }
-                try await expectNoThrow(timeout: 0.1, try funcThatThrows())
-            }
-            wait(for: [expectation], timeout: 1)
-        }
+        try await expectNoThrow(timeout: 0.1, try funcThatThrows())
+        XCTExpectFailure()
     }
     func testExpectNoThrowShouldSucceed() async throws {
         @Sendable func noThrow() async throws {}

--- a/Tests/AsyncExpectationsTests/ExpectNotEqualTests.swift
+++ b/Tests/AsyncExpectationsTests/ExpectNotEqualTests.swift
@@ -2,30 +2,13 @@ import XCTest
 @testable import AsyncExpectations
 
 final class ExpectNotEqualTests: XCTestCase {
-    func testExpectNotEqualShouldFail() throws {
-        XCTExpectFailure {
-            let expectation = expectation(description: #function)
-            Task {
-                defer {
-                    expectation.fulfill()
-                }
-                try await expectNotEqual(timeout: 0.1, { 2 }, { 2 })
-            }
-            wait(for: [expectation], timeout: 1)
-            
-        }
+    func testExpectNotEqualShouldFail() async throws {
+        try await expectNotEqual(timeout: 0.1, { 2 }, { 2 })
+        XCTExpectFailure()
     }
-    func testExpectNotEqualShouldFailAutoClosure() throws {
-        XCTExpectFailure {
-            let expectation = expectation(description: #function)
-            Task {
-                defer {
-                    expectation.fulfill()
-                }
-                try await expectNotEqual(timeout: 0.1, 2, 2)
-            }
-            wait(for: [expectation], timeout: 1)
-        }
+    func testExpectNotEqualShouldFailAutoClosure() async throws {
+        try await expectNotEqual(timeout: 0.1, 2, 2)
+        XCTExpectFailure()
     }
     func testExpectNotEqualShouldSucceed() async throws {
         try await expectNotEqual(1, 2)

--- a/Tests/AsyncExpectationsTests/ExpectTests.swift
+++ b/Tests/AsyncExpectationsTests/ExpectTests.swift
@@ -2,30 +2,13 @@ import XCTest
 @testable import AsyncExpectations
 
 final class ExpectTests: XCTestCase {
-    func testExpectShouldFail() throws {
-        XCTExpectFailure {
-            let expectation = expectation(description: #function)
-            Task {
-                defer {
-                    expectation.fulfill()
-                }
-                try await expect(timeout: 0.1, { return false })
-            }
-            wait(for: [expectation], timeout: 1)
-            
-        }
+    func testExpectShouldFail() async throws {
+        try await expect(timeout: 0.1, { return false })
+        XCTExpectFailure()
     }
-    func testExpectShouldFailAutoClosure() throws {
-        XCTExpectFailure {
-            let expectation = expectation(description: #function)
-            Task {
-                defer {
-                    expectation.fulfill()
-                }
-                try await expect(timeout: 0.1, false)
-            }
-            wait(for: [expectation], timeout: 1)
-        }
+    func testExpectShouldFailAutoClosure() async throws {
+        try await expect(timeout: 0.1, false)
+        XCTExpectFailure()
     }
     func testExpectShouldSucceed() async throws {
         try await expect {
@@ -35,11 +18,11 @@ final class ExpectTests: XCTestCase {
     } 
     @MainActor
     func testExpectShouldSucceedAutoClosure() async throws {
-        var fulfilled = false
+        let fulfilled = LockIsolated(false)
         Task { @MainActor in
             try await Task.sleep(nanoseconds: NSEC_PER_SEC / 10)
-            fulfilled = true
+            fulfilled.setValue(true)
         }
-        try await expect(fulfilled)
+        try await expect(fulfilled.value)
     }
 }

--- a/Tests/AsyncExpectationsTests/ExpectThrowsTests.swift
+++ b/Tests/AsyncExpectationsTests/ExpectThrowsTests.swift
@@ -2,42 +2,26 @@ import XCTest
 @testable import AsyncExpectations
 
 final class ExpectThrowsTests: XCTestCase {
-    func testExpectThrowsShouldFail() throws {
+    func testExpectThrowsShouldFail() async throws {
         @Sendable func noThrow() async throws {}
-        XCTExpectFailure {
-            let expectation = expectation(description: #function)
-            Task {
-                defer {
-                    expectation.fulfill()
-                }
-                try await expectThrowsError(timeout: 0.1) {
-                    try await noThrow()
-                }
-            }
-            wait(for: [expectation], timeout: 1)
+        try await expectThrowsError(timeout: 0.1) {
+            try await noThrow()
         }
+        XCTExpectFailure()
     }
-    func testExpectThrowsShouldFailAutoClosure() throws {
+    func testExpectThrowsShouldFailAutoClosure() async throws {
         @Sendable func noThrow() throws {}
-        XCTExpectFailure {
-            let expectation = expectation(description: #function)
-            Task {
-                defer {
-                    expectation.fulfill()
-                }
-                try await expectThrowsError(timeout: 0.1, try noThrow())
-            }
-            wait(for: [expectation], timeout: 1)
-        }
+        try await expectThrowsError(timeout: 0.1, try noThrow())
+        XCTExpectFailure()
     }
     func testExpectThrowsShouldSucceed() async throws {
-        func funcThatThrows() throws {
+        @Sendable func funcThatThrows() throws {
             throw "Foo"
         }
         try await expectThrowsError(try funcThatThrows())
     }
     func testExpectThrowsShouldSucceedAutoClosure() async throws {
-        func funcThatThrows() async throws {
+        @Sendable func funcThatThrows() async throws {
             try await Task.sleep(nanoseconds: NSEC_PER_SEC / 10)
             throw "Foo"
         }

--- a/Tests/AsyncExpectationsTests/ExpectValueTests.swift
+++ b/Tests/AsyncExpectationsTests/ExpectValueTests.swift
@@ -2,32 +2,47 @@ import XCTest
 @testable import AsyncExpectations
 
 final class ExpectValueTests: XCTestCase {
-    func testExpectValueShouldFailAutoClosure() throws {
-        XCTExpectFailure {
-            let expectation = expectation(description: #function)
-            Task {
-                defer {
-                    expectation.fulfill()
-                }
-                let value: Int? = nil
-                _ = try await expectValue(timeout: 0.1, value)
-            }
-            wait(for: [expectation], timeout: 1)
+    func testExpectValueShouldFailAutoClosure() async throws {
+        let value: Int? = nil
+        do {
+            try await expectValue(timeout: 0.1, value)
+        } catch {
+            XCTExpectFailure()
+            return
         }
+        XCTFail()
     }
     func testExpectValueShouldSucceed() async throws {
-        _ = try await expectValue({
+        try await expectValue({
             try await Task.sleep(nanoseconds: 10000)
             return 10
         })
     }
+    func testExpectAsyncValueShouldFail() async throws {
+        do {
+            try await expectValue {
+                try await Task.sleep(nanoseconds: 10000)
+                return Optional<Int>.none
+            }
+        } catch {
+            XCTExpectFailure()
+            return
+        }
+        XCTFail()
+    }
     func testExpectValueShouldSucceedAutoClosure() async throws {
-        _ = try await expectValue(2)
+        try await expectValue(2)
     }
     func testExpectValueShouldSucceedPublisher() async throws {
         let array = [3]
         let publisher = array.publisher
         let value = try await expectValue(publisher)
         XCTAssertEqual(value, 3)
+    }
+
+    func testExpectNil() async throws {
+        let value: Int? = 5
+        try await expectNil(timeout: 0.1, value)
+        XCTExpectFailure()
     }
 }


### PR DESCRIPTION
This PR mainly replaces @MainActor with @Sendable to not force the call site to be on the MainActor to address #3. 

I had to refactor most tests to make them pass. And isolate some state to fix Concurrency warnings. I'll add some review comments.